### PR TITLE
Update constructor parameters for easier initialization

### DIFF
--- a/core/src/AbstractSyntax/TupleExt.cs
+++ b/core/src/AbstractSyntax/TupleExt.cs
@@ -18,7 +18,7 @@ namespace Splaak.Core.AbstractSyntax
         /// Initializes a new instance of the <see cref="TupleExt"/> class.
         /// </summary>
         /// <param name="elements">The elements of this tuple.</param>
-        public TupleExt(IExprExt[] elements)
+        public TupleExt(params IExprExt[] elements)
         {
             Elements = elements;
         }

--- a/core/src/Reader/Expressions/SList.cs
+++ b/core/src/Reader/Expressions/SList.cs
@@ -19,7 +19,7 @@ namespace Splaak.Core.Reader.Expressions
         /// Initializes a new instance of the <see cref="SList"/> class.
         /// </summary>
         /// <param name="expressions">The expressions contained in this list.</param>
-        public SList(ISExpression[] expressions)
+        public SList(params ISExpression[] expressions)
         {
             Expressions = expressions;
         }

--- a/tests/src/AbstractSyntax/TupleExtTests.cs
+++ b/tests/src/AbstractSyntax/TupleExtTests.cs
@@ -9,7 +9,7 @@ namespace Splaak.Tests.AbstractSyntax
         private static IExprExt _1 = new IntExt(1);
         private static IExprExt _2 = new IntExt(2);
         private static IExprExt _3 = new IntExt(3);
-        private TupleExt _obj = new TupleExt(new[] { _1, _2, _3 });
+        private TupleExt _obj = new TupleExt(_1, _2, _3);
 
         [Fact]
         public void ConstructorTest()
@@ -22,7 +22,7 @@ namespace Splaak.Tests.AbstractSyntax
         [Fact]
         public void EqualsEqualTest()
         {
-            Assert.True(_obj.Equals(new TupleExt(new[] { _1, _2, _3 })));
+            Assert.True(_obj.Equals(new TupleExt(_1, _2, _3)));
         }
 
         [Fact]
@@ -34,13 +34,13 @@ namespace Splaak.Tests.AbstractSyntax
         [Fact]
         public void EqualsNotEqualLengthTest()
         {
-            Assert.False(_obj.Equals(new TupleExt(new[] { _1, _2 })));
+            Assert.False(_obj.Equals(new TupleExt(_1, _2)));
         }
 
         [Fact]
         public void EqualsNotEqualValueTest()
         {
-            Assert.False(_obj.Equals(new TupleExt(new[] { _1, _2, _2 })));
+            Assert.False(_obj.Equals(new TupleExt(_1, _2, _2)));
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace Splaak.Tests.AbstractSyntax
         [Fact]
         public void HashCodeEqualTest()
         {
-            Assert.Equal(_obj.GetHashCode(), new TupleExt(new[] { _1, _2, _3 }).GetHashCode());
+            Assert.Equal(_obj.GetHashCode(), new TupleExt(_1, _2, _3).GetHashCode());
         }
 
         [Fact]

--- a/tests/src/Reader/Expressions/SListTests.cs
+++ b/tests/src/Reader/Expressions/SListTests.cs
@@ -8,7 +8,7 @@ namespace Splaak.Tests.Reader.Expressions
     {
         private static SSym _1 = new SSym("bla");
         private static SInt _2 = new SInt(43);
-        private SList _obj = new SList(new ISExpression[] { _1, _2 });
+        private SList _obj = new SList(_1, _2);
 
         [Fact]
         public void ConstructorTest()
@@ -21,14 +21,14 @@ namespace Splaak.Tests.Reader.Expressions
         [Fact]
         public void EqualsEqualTest()
         {
-            Assert.True(_obj.Equals(new SList(new ISExpression[] { _1, _2 })));
+            Assert.True(_obj.Equals(new SList(_1, _2)));
         }
 
         [Fact]
         public void EqualsNullListTest()
         {
-            Assert.True(new SList(new ISExpression[] { null, null })
-                .Equals(new SList(new ISExpression[] { null, null })));
+            Assert.True(new SList(null, null)
+                .Equals(new SList(null, null)));
         }
 
         [Fact]
@@ -40,13 +40,13 @@ namespace Splaak.Tests.Reader.Expressions
         [Fact]
         public void EqualsNotEqualLengthTest()
         {
-            Assert.False(_obj.Equals(new SList(new ISExpression[] { _1 })));
+            Assert.False(_obj.Equals(new SList(_1)));
         }
 
         [Fact]
         public void EqualsNotEqualElementsTest()
         {
-            Assert.False(_obj.Equals(new SList(new ISExpression[] { _1, null })));
+            Assert.False(_obj.Equals(new SList(_1, null)));
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Splaak.Tests.Reader.Expressions
         [Fact]
         public void HashCodeEqualTest()
         {
-            Assert.Equal(_obj.GetHashCode(), new SList(new ISExpression[] { _1, _2 }).GetHashCode());
+            Assert.Equal(_obj.GetHashCode(), new SList(_1, _2).GetHashCode());
         }
 
         [Fact]

--- a/tests/src/Reader/SReaderTests.cs
+++ b/tests/src/Reader/SReaderTests.cs
@@ -33,19 +33,19 @@ namespace Splaak.Tests.Reader
         [Fact]
         public void ListSingleTest()
         {
-            Assert.Equal(SReader.Read("(5)"), new SList(new ISExpression[] { new SInt(5) }));
+            Assert.Equal(SReader.Read("(5)"), new SList(new SInt(5)));
         }
 
         [Fact]
         public void ListMultipleTest()
         {
-            Assert.Equal(SReader.Read("(5 true)"), new SList(new ISExpression[] { new SInt(5), new SSym("true") }));
+            Assert.Equal(SReader.Read("(5 true)"), new SList(new SInt(5), new SSym("true")));
         }
 
         [Fact]
         public void ListMultipleExtraSpacesTest()
         {
-            Assert.Equal(SReader.Read("(   5    true  )"), new SList(new ISExpression[] { new SInt(5), new SSym("true") }));
+            Assert.Equal(SReader.Read("(   5    true  )"), new SList(new SInt(5), new SSym("true")));
         }
 
         /*


### PR DESCRIPTION
Makes it easier to instantiate classes such as `SList` and `TupleExt` since an intermediate array is no longer necessary. See the [documentation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/params) for more details.